### PR TITLE
Remove calibration from telemetry messages

### DIFF
--- a/octoprint_nanny/manager.py
+++ b/octoprint_nanny/manager.py
@@ -111,8 +111,8 @@ class WorkerManager:
         """
 
         callbacks = {
-            Events.PLUGIN_OCTOPRINT_NANNY_MONITORING_START: self.monitoring_manager.start,
-            Events.PLUGIN_OCTOPRINT_NANNY_MONITORING_STOP: self.monitoring_manager.stop,
+            Events.PLUGIN_OCTOPRINT_NANNY_RC_MONITORING_START: self.monitoring_manager.start,
+            Events.PLUGIN_OCTOPRINT_NANNY_RC_MONITORING_STOP: self.monitoring_manager.stop,
         }
         self.mqtt_manager.publisher_worker.register_callbacks(callbacks)
         logger.info(f"Registered callbacks {callbacks} on publisher worker")

--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -541,17 +541,16 @@ class OctoPrintNannyPlugin(
 
     def register_custom_events(self):
         return [
+            # events from octoprint plugin
             "calibration_update",
             "predict_done",
-            "monitoring_start",
-            "monitoring_stop",
             "device_register_start",
             "device_register_done",
             "device_register_failed",
             "printer_profile_sync_start",
             "printer_profile_sync_done",
             "printer_profile_sync_failed",
-            # remote commands via RemoteControlCommand.CommandChoices (webapp)
+            # events from RemoteControlCommand.CommandChoices (webapp)
             "rc_print_start",
             "rc_print_stop",
             "rc_print_pause",
@@ -659,7 +658,6 @@ class OctoPrintNannyPlugin(
                 Events.PLUGIN_OCTOPRINT_NANNY_CALIBRATION_UPDATE,
                 payload={"calibration"},
             )
-            self.worker_manager.apply_monitoring_settings()
 
         if prev_auth_token != new_auth_token:
             logger.info("Change in auth detected, applying new settings")

--- a/octoprint_nanny/predictor.py
+++ b/octoprint_nanny/predictor.py
@@ -371,17 +371,9 @@ class PredictWorker:
         mqtt_msg = msg.copy()
         # publish bounding box prediction to mqtt telemetry topic
         # del mqtt_msg["original_image"]
-
-        calibration = (
-            self._calibration
-            if self._calibration is None
-            else self._calibration.get("coords")
-        )
         mqtt_msg.update(
             {
-                "calibration": calibration,
                 "event_type": "bounding_box_predict",
-                "fpm": self._fpm,
             }
         )
         mqtt_msg.update(prediction)

--- a/octoprint_nanny/workers/monitoring.py
+++ b/octoprint_nanny/workers/monitoring.py
@@ -64,7 +64,7 @@ class MonitoringManager:
         logger.info(f"Finished resetting MonitoringManager")
 
     @beeline.traced("MonitoringManager.start")
-    async def start(self):
+    async def start(self, **kwargs):
 
         self._reset()
 
@@ -79,7 +79,7 @@ class MonitoringManager:
         )
 
     @beeline.traced("MonitoringManager.stop")
-    async def stop(self):
+    async def stop(self, **kwargs):
         self._drain()
         await self.plugin.settings.rest_client.update_octoprint_device(
             self.plugin.settings.device_id, monitoring_active=False


### PR DESCRIPTION
Cloud IoT core charges for bandwidth; instead of sending calibration coordinates/mask on every inference, persist to a database row that can be referencing by DataFlow proc. 

closes #107 