### PR TITLE
Remove TensorFlow model from package data/manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include README.md
 recursive-include octoprint_nanny/templates *
 recursive-include octoprint_nanny/translations *
 recursive-include octoprint_nanny/static *
-recursive-include octoprint_nanny/data *

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ extra_requires = {
 # already be installed automatically if they exist. Note that if you add something here you'll also need to update
 # MANIFEST.in to match to ensure that python setup.py sdist produces a source distribution that contains all your
 # files. This is sadly due to how python's setup.py works, see also http://stackoverflow.com/a/14159430/2028598
-plugin_additional_data = ["data"]
+plugin_additional_data = []
 # Any additional python packages you need to install with your plugin that are not contained in <plugin_package>.*
 plugin_additional_packages = []
 


### PR DESCRIPTION
New model versions are now sent over the wire via MQTT config update, closes #143 