### PR TITLE
Fix error on plugin startup

### DIFF
--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -608,7 +608,7 @@ class OctoPrintNannyPlugin(
 
     def on_after_startup(self, *args, **kwargs):
         logger.info("OctoPrint Nanny startup complete, configuring logger")
-        configure_logger(logger, self.get_plugin_logfile_path())
+        configure_logger(logger, self._settings.get_plugin_logfile_path())
 
     def on_event(self, event_type, event_data):
         # shutdown event is handled in .on_shutdown


### PR DESCRIPTION
Fixes the following error on startup:

2021-04-25 01:51:32,666 - octoprint.plugin - ERROR - Error while calling plugin octoprint_nanny
Traceback (most recent call last):
  File "/home/leigh/projects/OctoPrint/.venv/lib/python3.7/site-packages/octoprint/plugin/__init__.py", line 271, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/leigh/projects/OctoPrint/.venv/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1890, in wrapper
    return f(*args, **kwargs)
  File "/home/leigh/projects/OctoPrint/.venv/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1890, in wrapper
    return f(*args, **kwargs)
  File "/home/leigh/projects/octoprint-nanny-plugin/octoprint_nanny/plugins.py", line 611, in on_after_startup
    configure_logger(logger, self.get_plugin_logfile_path())