### PR TITLE
Wrap coroutine in asyncio.ensure_future() to ensure errors are re-raised

### DIFF
--- a/octoprint_nanny/workers/websocket.py
+++ b/octoprint_nanny/workers/websocket.py
@@ -88,7 +88,7 @@ class WebSocketWorker:
         self._halt = halt
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        return loop.run_until_complete(self.relay_loop())
+        return loop.run_until_complete(asyncio.ensure_future(self.relay_loop()))
 
     async def _loop(self, websocket):
         try:


### PR DESCRIPTION

Current behavior:
```
2021-06-01 00:14:59,660 - asyncio - WARNING - socket.send() raised exception.
2021-06-01 00:15:00,761 - asyncio - WARNING - socket.send() raised exception.
2021-06-01 00:15:01,839 - asyncio - WARNING - socket.send() raised exception.
2021-06-01 00:15:02,943 - asyncio - WARNING - socket.send() raised exception.
2021-06-01 00:15:04,034 - asyncio - WARNING - socket.send() raised exception.
```

