### PR TITLE
Fix protobuf pyobject init

### DIFF
--- a/octoprint_nanny/clients/protobuf.py
+++ b/octoprint_nanny/clients/protobuf.py
@@ -11,6 +11,9 @@ from print_nanny_client.protobuf.monitoring_pb2 import MonitoringImage
 def build_monitoring_image(
     image_bytes: bytes, height: int, width: int, metadata_pb: Metadata
 ) -> MonitoringImage:
-    return MonitoringImage(
-        data=image_bytes, height=height, width=width, metadata=metadata_pb
-    )
+    pb = MonitoringImage()
+    pb.data = image_bytes
+    pb.height = height
+    pb.width = width
+    pb.metadata.CopyFrom(metadata_pb)
+    return pb

--- a/octoprint_nanny/clients/protobuf.py
+++ b/octoprint_nanny/clients/protobuf.py
@@ -11,9 +11,6 @@ from print_nanny_client.protobuf.monitoring_pb2 import MonitoringImage
 def build_monitoring_image(
     image_bytes: bytes, height: int, width: int, metadata_pb: Metadata
 ) -> MonitoringImage:
-    pb = MonitoringImage()
-    pb.data = image_bytes
-    pb.height = height
-    pb.width = width
-    pb.metadata.CopyFrom(metadata_pb)
-    return pb
+    return MonitoringImage(
+        data=image_bytes, height=height, width=width, metadata=metadata_pb
+    )

--- a/octoprint_nanny/settings.py
+++ b/octoprint_nanny/settings.py
@@ -271,12 +271,13 @@ class PluginSettingsMemoize:
         )
         logger.info(f"Created print_session={print_session}")
         self._print_session_rest = print_session
-        self._print_session_pb = print_nanny_client.protobuf.common_pb2.PrintSession(
-            session=session,
-            id=print_session.id,
-            created_ts=now.timestamp(),
-            datesegment=print_session.datesegment,
-        )
+        pb = print_nanny_client.protobuf.common_pb2.PrintSession()
+
+        pb.session = session
+        pb.id = print_session.id
+        pb.created_ts = now.timestamp()
+        pb.datesegment = print_session.datesegment
+        self._print_session_pb = pb
         return self._print_session_rest
 
     @property
@@ -312,40 +313,46 @@ class PluginSettingsMemoize:
     @property
     def metadata_pb(self):
         ts = datetime.now(pytz.timezone("UTC")).timestamp()
-        return print_nanny_client.protobuf.monitoring_pb2.Metadata(
-            user_id=self.user_id,
-            octoprint_device_id=self.octoprint_device_id,
-            cloudiot_device_id=self.cloudiot_device_id,
-            print_session=self.print_session_pb,
-            ts=ts,
-            octoprint_environment=self.octoprint_environment_pb,
-        )
+
+        pb = print_nanny_client.protobuf.monitoring_pb2.Metadata()
+        pb.user_id = self.user_id
+        pb.octoprint_device_id = self.octoprint_device_id
+        pb.cloudiot_device_id = self.cloudiot_device_id
+        pb.print_session.CopyFrom(self.print_session_pb)
+        pb.octoprint_environment.CopyFrom(self.octoprint_environment_pb)
+        pb.ts = ts
+        logger.info(f"Created ts={pb.ts} from ts={ts}")
+        return pb
 
     @property
     def octoprint_environment_pb(self):
         octoprint_environment = self.octoprint_environment
-        return print_nanny_client.protobuf.common_pb2.OctoprintEnvironment(
-            plugin_version=self.plugin_version,
-            client_version=print_nanny_client.__version__,
-            python_version=octoprint_environment.get("python", {}).get("version"),
-            pip_version=octoprint_environment.get("python", {}).get("pip"),
-            octopi_version=octoprint_environment.get("plugins", {})
+        pb = print_nanny_client.protobuf.common_pb2.OctoprintEnvironment()
+        pb.plugin_version = self.plugin_version
+        pb.client_version = print_nanny_client.__version__
+        pb.python_version = octoprint_environment.get("python", {}).get("version")
+        pb.pip_version = octoprint_environment.get("python", {}).get("pip")
+
+        pb.octopi_version = (
+            octoprint_environment.get("plugins", {})
             .get("pi_support", {})
-            .get("octopi_version"),
-            virtualenv=octoprint_environment.get("python", {}).get("virtualenv"),
-            platform=octoprint_environment.get("os", {}).get("platform"),
-            bits=octoprint_environment.get("os", {}).get("bits"),
-            cores=octoprint_environment.get("hardware", {}).get("cores"),
-            freq=octoprint_environment.get("hardware", {}).get("freq"),
-            ram=octoprint_environment.get("hardware", {}).get("ram"),
-            pi_model=octoprint_environment.get("plugins", {})
-            .get("pi_support", {})
-            .get("model"),
-            pi_throttle_state=octoprint_environment.get("plugins", {})
-            .get("pi_support", {})
-            .get("throttle_state"),
-            octoprint_version=octoprint.util.version.get_octoprint_version_string(),
+            .get("octopi_version")
         )
+        pb.virtualenv = octoprint_environment.get("python", {}).get("virtualenv")
+        pb.platform = octoprint_environment.get("os", {}).get("platform")
+        pb.bits = octoprint_environment.get("os", {}).get("bits")
+        pb.cores = octoprint_environment.get("hardware", {}).get("cores")
+        pb.freq = octoprint_environment.get("hardware", {}).get("freq")
+        pb.ram = octoprint_environment.get("hardware", {}).get("ram")
+        pb.pi_model = octoprint_environment.get("plugins", {}).get("pi_support", {}).get("model")
+        
+        pb.pi_throttle_state = (
+            octoprint_environment.get("plugins", {})
+            .get("pi_support", {})
+            .get("throttle_state")
+        )
+        pb.octoprint_version = octoprint.util.version.get_octoprint_version_string()
+        return pb
 
     def calc_calibration_mask(
         self, x0: float, y0: float, x1: float, y1: float, height=480, width=640

--- a/octoprint_nanny/workers/mqtt.py
+++ b/octoprint_nanny/workers/mqtt.py
@@ -204,7 +204,6 @@ class MQTTPublisherWorker:
                 height=h,
                 metadata_pb=self.plugin_settings.metadata_pb,
             )
-
             b64_image = base64.b64encode(image_bytes)
             if self.plugin_settings.monitoring_active:
                 self.plugin._event_bus.fire(

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,7 +120,7 @@ pillow==8.2.0
     # via OctoPrint-Nanny (setup.py)
 pkginfo==1.7.0
     # via octoprint
-print-nanny-client==0.7.0.dev25
+print-nanny-client==0.7.0.dev27
     # via OctoPrint-Nanny (setup.py)
 protobuf==3.17.3
     # via print-nanny-client

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ plugin_requires = [
     "typing_extensions ; python_version < '3.8'",
     "pytz",
     "aiohttp[speedups]>=3.7.4",
-    "print-nanny-client>=0.7.0dev25",
+    "print-nanny-client>=0.7.0dev27",
     "backoff>=1.10.0",
     "pyjwt>=2.0.1",
     "paho-mqtt>=1.5.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,12 +131,12 @@ def metadata(octoprint_environment):
 
 @pytest.fixture
 def metadata_pb():
-    return print_nanny_client.protobuf.monitoring_pb2.Metadata(
-        user_id=1234,
-        octoprint_device_id=1234,
-        cloudiot_device_id=1234,
-        ts=datetime.now().timestamp(),
-    )
+    pb = print_nanny_client.protobuf.monitoring_pb2.Metadata()
+    pb.user_id = 1234
+    pb.octoprint_device_id = 1234
+    pb.cloudiot_device_id = 1234
+    pb.ts = datetime.now().timestamp()
+    return pb
 
 
 def pytest_addoption(parser):
@@ -155,12 +155,13 @@ def plugin_settings(
 ):
     plugin_settings = mocker.Mock()
     plugin_settings.metadata = metadata
-    plugin_settings.print_session_pb = PrintSession(
-        id=1,
-        session=uuid.uuid4().hex,
-        created_ts=datetime.now().timestamp(),
-        datesegment="2021/01/01",
-    )
+
+    pb = PrintSession()
+    pb.id = 1
+    pb.session = uuid.uuid4().hex
+    pb.created_ts = datetime.now().timestamp()
+    pb.datesegment = "2021/01/01"
+    plugin_settings.print_session_pb = pb
 
     plugin_settings.metadata_pb = metadata_pb
     plugin_settings.current_printer_state = current_printer_state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,12 +131,12 @@ def metadata(octoprint_environment):
 
 @pytest.fixture
 def metadata_pb():
-    pb = print_nanny_client.protobuf.monitoring_pb2.Metadata()
-    pb.user_id = 1234
-    pb.octoprint_device_id = 1234
-    pb.cloudiot_device_id = 1234
-    pb.ts = datetime.now().timestamp()
-    return pb
+    return print_nanny_client.protobuf.monitoring_pb2.Metadata(
+        user_id=1234,
+        octoprint_device_id=1234,
+        cloudiot_device_id=1234,
+        ts=datetime.now().timestamp(),
+    )
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Protobuf's python implementation does not use PyObject init, which was resulting in the following incorrect memory pointers being used

left: protobuf, right: python float
```
2021-06-20 19:25:54,967 - octoprint.plugins.octoprint_nanny.workers.monitoring - INFO - Initialized ws connection
2021-06-20 19:25:56,139 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213556.137391
2021-06-20 19:25:57,202 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213557.200458
2021-06-20 19:25:58,306 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213558.303977
2021-06-20 19:25:59,402 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213559.401442
2021-06-20 19:26:00,504 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213560.503366
2021-06-20 19:26:01,602 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213561.599445
2021-06-20 19:26:02,700 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213562.698943
2021-06-20 19:26:03,804 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213563.803419
2021-06-20 19:26:04,901 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213564.89998
2021-06-20 19:26:06,002 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213566.001028
2021-06-20 19:26:07,099 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213504.0 from ts=1624213567.09775
2021-06-20 19:26:08,206 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213632.0 from ts=1624213568.204755
2021-06-20 19:26:09,302 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213632.0 from ts=1624213569.300985
2021-06-20 19:26:10,402 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213632.0 from ts=1624213570.401801
2021-06-20 19:26:11,499 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213632.0 from ts=1624213571.498288
2021-06-20 19:26:12,598 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213632.0 from ts=1624213572.596601
2021-06-20 19:26:13,702 - octoprint.plugins.octoprint_nanny.settings - INFO - Created ts=1624213632.0 from ts=1624213573.70074
```