### PR TITLE
Release v0.7.2

### DIFF
--- a/octoprint_nanny/__init__.py
+++ b/octoprint_nanny/__init__.py
@@ -7,7 +7,7 @@ __plugin_name__ = "OctoPrint Nanny"
 
 __plugin_pythoncompat__ = ">=3,<4"  # only python 3
 
-__plugin_version__ = "0.7.1"
+__plugin_version__ = "0.7.2rc2"
 
 
 def __plugin_load__():

--- a/octoprint_nanny/__init__.py
+++ b/octoprint_nanny/__init__.py
@@ -7,7 +7,7 @@ __plugin_name__ = "OctoPrint Nanny"
 
 __plugin_pythoncompat__ = ">=3,<4"  # only python 3
 
-__plugin_version__ = "0.7.2rc2"
+__plugin_version__ = "0.7.2"
 
 
 def __plugin_load__():

--- a/octoprint_nanny/clients/mqtt.py
+++ b/octoprint_nanny/clients/mqtt.py
@@ -296,7 +296,7 @@ class MQTTClient:
         while not self.exit.is_set():
             self.client.loop()
 
-    def shutdown(self):
+    def shutdown(self, **kwargs):
         self.exit.set()
 
 

--- a/octoprint_nanny/manager.py
+++ b/octoprint_nanny/manager.py
@@ -132,7 +132,7 @@ class WorkerManager:
             pass
 
     @beeline.traced("WorkerManager.shutdown")
-    async def shutdown(self):
+    async def shutdown(self, **kwargs):
 
         await self.monitoring_manager.stop()
         self.mqtt_manager.shutdown()

--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -141,7 +141,7 @@ class OctoPrintNannyPlugin(
         self._calibration = None
 
         self._log_path = None
-        self._environment = {}
+        self._octoprint_environment = {}
 
         self.monitoring_active = False
         self.worker_manager = WorkerManager(plugin=self)
@@ -274,10 +274,10 @@ class OctoPrintNannyPlugin(
         # covnert kB string like '3867172 kB' to int
         ram = int(self._meminfo().get("memtotal").split()[0])
 
-        logger.info(f"Runtime environment:\n {self._environment}")
-        python_version = self._environment.get("python", {}).get("version")
-        pip_version = self._environment.get("python", {}).get("pip")
-        virtualenv = self._environment.get("python", {}).get("virtualenv")
+        logger.info(f"Runtime environment:\n {self._octoprint_environment}")
+        python_version = self._octoprint_environment.get("python", {}).get("version")
+        pip_version = self._octoprint_environment.get("python", {}).get("pip")
+        virtualenv = self._octoprint_environment.get("python", {}).get("virtualenv")
 
         return {
             "model": cpuinfo.get("model"),
@@ -508,6 +508,9 @@ class OctoPrintNannyPlugin(
             context={"name": "update_or_create_octoprint_device"}
         )
         try:
+            logger.info(
+                f"update_or_create_octoprint_device from device_info={device_info}"
+            )
             device = await self.worker_manager.plugin.settings.rest_client.update_or_create_octoprint_device(
                 name=device_name, **device_info
             )

--- a/octoprint_nanny/static/js/nanny.js
+++ b/octoprint_nanny/static/js/nanny.js
@@ -117,7 +117,7 @@ $(function () {
                         self.statusCheckActive(false);
                         self.statusCheckSuccess(false);
                         self.statusCheckFailed(true);
-                        self.apiStatusMessage(message.data.error);
+                        self.apiStatusMessage(message.data.payload.error);
                         self.apiStatusClass('danger');
                         break
                     case 'plugin_octoprint_nanny_connect_test_rest_api_success':
@@ -130,7 +130,7 @@ $(function () {
                         self.statusCheckActive(false);
                         self.statusCheckSuccess(false);
                         self.statusCheckFailed(true);
-                        self.mqttPingStatusMessage(message.data.error);
+                        self.mqttPingStatusMessage(message.data.payload.error);
                         self.mqttPingStatusClass('danger');
                         break
                     case 'plugin_octoprint_nanny_connect_test_mqtt_ping_success':

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.2rc2
+current_version = 0.7.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>(dev|rc))+(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.1
+current_version = 0.7.2rc2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>(dev|rc))+(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ plugin_package = "octoprint_nanny"
 plugin_name = "OctoPrint Nanny"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.7.1"
+plugin_version = "0.7.2rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ plugin_package = "octoprint_nanny"
 plugin_name = "OctoPrint Nanny"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.7.2rc2"
+plugin_version = "0.7.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* initialize print session if None set in telemetry payload builder; reset print session on PRINE_DONE PRINT_FAILED PRINT_CANCELLED events

* refer to octoprint environment dict as octoprint_environment everywhere; log device info before upsert

* fix exception in MQTT manager shutdown handler, handle exceptions in publish_octoprint_event_telemetry

* simplify print_session creation and reset

* revert sync build_telemetry_event

* fix mypy