### PR TITLE
MQTT worker graceful startup/shutdown

### DIFF
--- a/octoprint_nanny/static/js/nanny.js
+++ b/octoprint_nanny/static/js/nanny.js
@@ -117,7 +117,7 @@ $(function () {
                         self.statusCheckActive(false);
                         self.statusCheckSuccess(false);
                         self.statusCheckFailed(true);
-                        self.apiStatusMessage(message.data.payload.error);
+                        self.apiStatusMessage(message.data.payload.error + '\n Try restarting OctoPrint and running this test again.');
                         self.apiStatusClass('danger');
                         break
                     case 'plugin_octoprint_nanny_connect_test_rest_api_success':
@@ -130,7 +130,7 @@ $(function () {
                         self.statusCheckActive(false);
                         self.statusCheckSuccess(false);
                         self.statusCheckFailed(true);
-                        self.mqttPingStatusMessage(message.data.payload.error);
+                        self.mqttPingStatusMessage(message.data.payload.error + '\n Try restarting OctoPrint and running this test again.');
                         self.mqttPingStatusClass('danger');
                         break
                     case 'plugin_octoprint_nanny_connect_test_mqtt_ping_success':

--- a/octoprint_nanny/workers/mqtt.py
+++ b/octoprint_nanny/workers/mqtt.py
@@ -14,7 +14,7 @@ import PIL
 import io
 import beeline
 import base64
-from typing import List, Callable, Dict, Any
+from typing import List, Callable, Dict, Any, Union
 import print_nanny_client
 
 from octoprint.events import Events
@@ -35,6 +35,7 @@ from octoprint_nanny.types import (
 )
 from octoprint_nanny.clients.protobuf import build_monitoring_image
 from octoprint_nanny.settings import PluginSettingsMemoize
+from octoprint_nanny.clients.mqtt import MQTTClient
 
 logger = logging.getLogger("octoprint.plugins.octoprint_nanny.workers.mqtt")
 
@@ -87,6 +88,7 @@ class MQTTManager:
         self.subscriber_worker = MQTTSubscriberWorker(
             self.mqtt_receive_queue, self.plugin, self.plugin_settings
         )
+        self._workers:List[Union[MQTTPublisherWorker, MQTTSubscriberWorker, MQTTClient]] = []
 
     def _reset(self):
         self.exit = threading.Event()
@@ -105,6 +107,7 @@ class MQTTManager:
             logger.warning(
                 "MQTTManager.start was called without device registration set, ignoring"
             )
+            return
 
         logger.info("MQTTManager.start was called")
 

--- a/octoprint_nanny/workers/mqtt.py
+++ b/octoprint_nanny/workers/mqtt.py
@@ -88,7 +88,9 @@ class MQTTManager:
         self.subscriber_worker = MQTTSubscriberWorker(
             self.mqtt_receive_queue, self.plugin, self.plugin_settings
         )
-        self._workers:List[Union[MQTTPublisherWorker, MQTTSubscriberWorker, MQTTClient]] = []
+        self._workers: List[
+            Union[MQTTPublisherWorker, MQTTSubscriberWorker, MQTTClient]
+        ] = []
 
     def _reset(self):
         self.exit = threading.Event()


### PR DESCRIPTION
If something went wrong during MQTT client initialization (network timeout, device registration failed, etc), two fatal exceptions were thrown on subsequent server startup/shutdown. This fixes both.

on startup:
```
2021-07-04 22:16:46,027 - octoprint - ERROR - Error while trying to migrate settings for plugin octoprint_nanny, ignoring it
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/__init__.py", line 512, in init_settings_plugin_config_migration_and_cleanup
    implementation._identifier, implementation
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/__init__.py", line 506, in settings_plugin_config_migration_and_cleanup
    implementation.on_settings_initialized()
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1941, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/beeline/aiotrace.py", line 93, in inner
    return fn(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_nanny/plugins.py", line 764, in on_settings_initialized
    self.worker_manager.on_settings_initialized()
  File "/home/pi/oprint/lib/python3.7/site-packages/beeline/aiotrace.py", line 93, in inner
    return fn(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_nanny/manager.py", line 106, in on_settings_initialized
    self.mqtt_manager.start()
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_nanny/workers/mqtt.py", line 114, in start
    mqtt_client,
UnboundLocalError: local variable 'mqtt_client' referenced before assignment
```

on shutdown:

```
2021-07-04 22:18:33,250 - octoprint.plugin - ERROR - Error while calling plugin octoprint_nanny
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/plugin/__init__.py", line 271, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1941, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_nanny/plugins.py", line 725, in on_event
    self.worker_manager.mqtt_client_reset()
  File "/home/pi/oprint/lib/python3.7/site-packages/beeline/aiotrace.py", line 93, in inner
    return fn(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_nanny/manager.py", line 110, in mqtt_client_reset
    self.mqtt_manager.shutdown()
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_nanny/workers/mqtt.py", line 127, in shutdown
    for worker in self._workers:
AttributeError: 'MQTTManager' object has no attribute '_workers'
```
