### PR TITLE
use a relative url for PrintNanny banner img

### DIFF
--- a/octoprint_nanny/templates/octoprint_nanny_settings_shared.jinja2
+++ b/octoprint_nanny/templates/octoprint_nanny_settings_shared.jinja2
@@ -1,6 +1,6 @@
 <!-- hero -->
 <div class="row-fluid">
-    <a href="{{ plugin_octoprint_nanny_urls.cloud }}"><img src="/plugin/octoprint_nanny/static/img/print_nanny_logo.png"/></a>
+    <a href="{{ plugin_octoprint_nanny_urls.cloud }}"><img src="plugin/octoprint_nanny/static/img/print_nanny_logo.png"/></a>
     <hr>
     <h3>About PrintNanny OS (OctoPrint Edition)</h3>
     <a target="_blank" href="{{ plugin_octoprint_nanny_urls.discord_invite }}"><button class="btn btn-primary">Join Discord</button></a>


### PR DESCRIPTION
Fixes 404 when OctoPrint is served from /octoprint/ path:
![Screenshot from 2022-04-19 09-56-03](https://user-images.githubusercontent.com/2601819/164055997-4c4ca2bd-2b73-4b21-8314-f1b9453623f7.png)

