### PR TITLE
fix more config accessors in jinja templates

### DIFF
--- a/octoprint_nanny/templates/octoprint_nanny_settings_shared.jinja2
+++ b/octoprint_nanny/templates/octoprint_nanny_settings_shared.jinja2
@@ -24,7 +24,7 @@
 {% if plugin_octoprint_nanny_settings.printnanny_config != none %}
 </div>
     <ul class="nav nav-tabs">
-        <li class="active"><a href="#{{template_name}}_basic" data-toggle="tab">{{ _('Settings') }}</a></li>
+        <li class="active"><a href="#{{template_name}}_basic" data-toggle="tab">{{ _('Account') }}</a></li>
         <li><a href="#{{template_name}}_about" data-toggle="tab">{{ _('About') }}</a></li>
     </ul>
 
@@ -37,7 +37,7 @@
             <h3>Log into PrintNanny</h3>
             <a href="{{ plugin_octoprint_nanny_settings.printnanny_config.dash.base_url }}" class="btn btn-primary btn-large">Link PrintNanny Account</a>
             <p>You'll be redirected to another page to log into your PrintNanny account</p>
-            {% elif  plugin_octoprint_nanny_settings.printnanny_config is not none %}
+            {% else  plugin_octoprint_nanny_settings.printnanny_config %}
             <h3>Welcome to PrintNanny OS (OctoPrint Edition)</h3>
             <p>🙌 Your PrintNanny account is connected: <strong>{{ plugin_octoprint_nanny_settings.printnanny_config.user.email }}</strong></p>
             <br>
@@ -45,10 +45,13 @@
             {% endif %}
         </div>
       </fieldset>
-      </div>
+    </div>
     <div id="{{template_name}}_about" class="tab-pane">
 
     </div>
 
 </div>
 {% endif %}
+<script type="text/javascript">
+PRINTNANNY_CONFIG = 
+</script>

--- a/octoprint_nanny/templates/octoprint_nanny_tab.jinja2
+++ b/octoprint_nanny/templates/octoprint_nanny_tab.jinja2
@@ -1,4 +1,4 @@
-{% if plugin_octoprint_nanny_settings.printnanny_config is not none %}
+{% if plugin_octoprint_nanny_settings.printnanny_config != none and  plugin_octoprint_nanny_settings.printnanny_config.device is defined %}
 <span class="janus-stream-app">
     <janus-stream 
         device-id="{{ plugin_octoprint_nanny_settings.printnanny_config.device.id }}"
@@ -7,7 +7,7 @@
 </span>
 {% endif %}
 
-{% if plugin_octoprint_nanny_settings.printnanny_config and plugin_octoprint_nanny_settings.printnanny_config.api %}
+{% if plugin_octoprint_nanny_settings.printnanny_config and plugin_octoprint_nanny_settings.printnanny_config.api is defined %}
 <script type="text/javascript">
 window.PRINTNANNY_API_TOKEN = "{{ plugin_octoprint_nanny_settings.printnanny_config.api.bearer_access_token }}"
 </script>


### PR DESCRIPTION
Fixes the following error in the latest nightly + rc1
```
Apr 19 10:11:05 octonanny-04-18 octoprint[451]: Traceback (most recent call last):
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/octoprint/util/jinja.py", line 255, in _handle_body
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     return caller()
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/jinja2/runtime.py", line 763, in __call__
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     return self._invoke(arguments, autoescape)
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/jinja2/runtime.py", line 777, in _invoke
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     rv = self._func(*arguments)
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/octoprint/templates/index.jinja2", line 106, in macro
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     <div id="{{ data._div }}"
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/octoprint_nanny/templates/octoprint_nanny_navbar.jinja2", line 16, in root
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/jinja2/environment.py", line 475, in getattr
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     return getattr(obj, attribute)
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/jinja2/runtime.py", line 859, in __getattr__
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     return self._fail_with_undefined_error()
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:   File "/home/pi/.octoprint/venv/lib/python3.9/site-packages/jinja2/runtime.py", line 852, in _fail_with_undefined_error
Apr 19 10:11:05 octonanny-04-18 octoprint[451]:     raise self._undefined_exception(self._undefined_message)
Apr 19 10:11:05 octonanny-04-18 octoprint[451]: jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'device'
```