### PR TITLE
initialize settings defaults in fn instead of module scope

### DIFF
--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -58,15 +58,6 @@ DEFAULT_MQTT_BRIDGE_HOSTNAME = os.environ.get(
 DEFAULT_MQTT_ROOT_CERTIFICATE_URL = "https://pki.google.com/roots.pem"
 BACKUP_MQTT_ROOT_CERTIFICATE_URL = "https://pki.goog/gsr4/GSR4.crt"
 
-DEFAULT_SETTINGS = dict(
-    printnanny_version=printnanny_version(),
-    printnanny_config=printnanny_config(),
-    backup_auto=False,
-    analytics_enabled=False,
-    events_enabled=False,
-    wizard_complete=-1,
-)
-
 Events.PRINT_PROGRESS = "PrintProgress"
 
 
@@ -220,6 +211,14 @@ class OctoPrintNannyPlugin(
 
     ## SettingsPlugin mixin
     def get_settings_defaults(self):
+        DEFAULT_SETTINGS = dict(
+            printnanny_version=printnanny_version(),
+            printnanny_config=printnanny_config(),
+            backup_auto=False,
+            analytics_enabled=False,
+            events_enabled=False,
+            wizard_complete=-1,
+        )
         return DEFAULT_SETTINGS
 
     ## Template plugin


### PR DESCRIPTION
Fixes issue where wizard prompts for account link, even if account is already linked. If this doesn't work, might need to read printnanny_config in template vars fn.
![Screenshot from 2022-04-21 11-54-27](https://user-images.githubusercontent.com/2601819/164533195-9ff285a2-8189-4d8d-8edd-51e7394b6c4c.png)

