### PR TITLE
Hotfix: read Janus API url from printnanny config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,6 @@ PRINTNANNY_PLUGIN_VERSION=$(shell git rev-parse HEAD)
 
 PRINTNANNY_BIN ?= $(TMP_DIR)/printnanny-cli/target/debug/printnanny-cli
 
-JANUS_EDGE_HOSTNAME ?= localhost
-JANUS_API_TOKEN ?= janustoken
-
 BITBAKE_RECIPE ?= $(HOME)/projects/poky/meta-bitsy/meta-printnanny/recipes-core/octoprint
 
 $(PRINTNANNY_CONFD):

--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -114,8 +114,12 @@ class OctoPrintNannyPlugin(
     ##~~ SettingsPlugin mixin
     def get_settings_defaults(self):
         config = load_printnanny_config()
-        janusApiUrl = config.get("janus_edge", {}).get("api_http_url", "")
-        janusApiToken = config.get("janus_edge", {}).get("api_token", "")
+        janusApiUrl = (
+            config.get("config", {}).get("janus_edge", {}).get("api_http_url", "")
+        )
+        janusApiToken = (
+            config.get("config", {}).get("janus_edge", {}).get("api_token", "")
+        )
 
         DEFAULT_SETTINGS = dict(
             janusApiUrl=janusApiUrl,

--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -12,8 +12,6 @@ from octoprint_nanny.events import try_handle_event
 from octoprint_nanny.utils.printnanny_os import (
     issue_txt,
     load_printnanny_config,
-    janus_edge_hostname,
-    janus_edge_api_token,
     etc_os_release,
     is_printnanny_os,
 )
@@ -115,8 +113,9 @@ class OctoPrintNannyPlugin(
 
     ##~~ SettingsPlugin mixin
     def get_settings_defaults(self):
-        janusApiUrl = "http://{}:8088/janus".format(socket.gethostname())
-        janusApiToken = janus_edge_api_token()
+        config = load_printnanny_config()
+        janusApiUrl = config.get("janus_edge", {}).get("api_http_url", "")
+        janusApiToken = config.get("janus_edge", {}).get("api_token", "")
 
         DEFAULT_SETTINGS = dict(
             janusApiUrl=janusApiUrl,

--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -135,8 +135,6 @@ class OctoPrintNannyPlugin(
                 "discord_invite": "https://discord.gg/sf23bk2hPr",
                 "webapp": PRINTNANNY_WEBAPP_BASE_URL,
             },
-            "janus_edge_hostname": janus_edge_hostname(),
-            "janus_edge_api_token": janus_edge_api_token(),
             "issue_txt": issue_txt(),
             "etc_os_release": etc_os_release(),
             "config": load_printnanny_config(),

--- a/octoprint_nanny/utils/printnanny_os.py
+++ b/octoprint_nanny/utils/printnanny_os.py
@@ -61,14 +61,6 @@ def load_printnanny_config() -> PrintNannyConfig:
     )
 
 
-def janus_edge_hostname() -> str:
-    return environ.get("JANUS_EDGE_HOSTNAME", "localhost")
-
-
-def janus_edge_api_token() -> str:
-    return environ.get("JANUS_EDGE_API_TOKEN", "janustoken")
-
-
 def issue_txt() -> str:
     """
     Captured the contents of /etc/issue as plain text


### PR DESCRIPTION
The default value is invalid in the latest 0.2.0 build. Should be using a single source of truth (PrintNanny config CLI) instead of trying to set defaults adhoc.
![Screenshot from 2022-07-08 14-23-34](https://user-images.githubusercontent.com/2601819/178072377-1d528249-54a6-4785-84ea-316cfe95b5ae.png)

