### PR TITLE
Fix error: Cannot run the event loop while another loop is running

### DIFF
--- a/octoprint_nanny/utils/printnanny_os.py
+++ b/octoprint_nanny/utils/printnanny_os.py
@@ -33,8 +33,11 @@ async def deserialize_pi(pi_dict) -> Pi:
 
 
 def load_pi_model(pi_dict: Dict[str, Any]) -> Pi:
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     coroutine = deserialize_pi(pi_dict)
     result = loop.run_until_complete(coroutine)
     global PRINTNANNY_PI


### PR DESCRIPTION
Fixes an error in 0.13.0 production builds:

```
Aug 22 14:56:09 pn-0-3-0 octoprint[736]: 2022-08-22 14:56:09,475 - octoprint.server.api - ERROR - There was an error fetching wizard details for octoprint_nanny, ignoring
Aug 22 14:56:09 pn-0-3-0 octoprint[736]: Traceback (most recent call last):
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/site-packages/octoprint/server/api/__init__.py", line 189, in wizardState
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     required = implementation.is_wizard_required()
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/site-packages/octoprint/util/__init__.py", line 1688, in wrapper
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     return f(*args, **kwargs)
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/site-packages/octoprint_nanny/plugins.py", line 158, in is_wizard_required
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     printnanny_os.load_printnanny_config()
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/site-packages/octoprint_nanny/utils/printnanny_os.py", line 85, in load_printnanny_config
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     load_pi_model(pi)
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/site-packages/octoprint_nanny/utils/printnanny_os.py", line 39, in load_pi_model
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     result = loop.run_until_complete(coroutine)
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/asyncio/base_events.py", line 622, in run_until_complete
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     self._check_running()
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:   File "/usr/lib/python3.10/asyncio/base_events.py", line 584, in _check_running
Aug 22 14:56:09 pn-0-3-0 octoprint[736]:     raise RuntimeError(
Aug 22 14:56:09 pn-0-3-0 octoprint[736]: RuntimeError: Cannot run the event loop while another loop is running
```