### PR TITLE
Remove octoprint cam warning

### DIFF
--- a/octoprint_nanny/__init__.py
+++ b/octoprint_nanny/__init__.py
@@ -5,7 +5,7 @@ __plugin_name__ = "OctoPrint-Nanny"
 
 __plugin_pythoncompat__ = ">=3,<4"  # only python 3
 
-__plugin_version__ = "0.13.6"
+__plugin_version__ = "0.14.0"
 
 
 def __plugin_load__():

--- a/octoprint_nanny/static/js/octo_printnanny.js
+++ b/octoprint_nanny/static/js/octo_printnanny.js
@@ -83,18 +83,18 @@ $(function () {
 });
 
 
-$(function () {
-    function CameraWarningViewModel(parameters) {
+// $(function () {
+//     function CameraWarningViewModel(parameters) {
 
-        $('#settings_webcam h3:first-of-type').after('<div class="alert alert-printnanny alert-block"><h4 class="alert-heading">Note from PrintNanny</h4><p>The setting below do not apply to PrintNanny\'s web camera!</p><p> Use PrintNanny\'s Camera settings tab instead. </p><p><a data-toggle="tab" href="#settings_plugin_octoprint_nanny" class="btn btn-primary">Open PrintNanny Settings</a></p></div>')
-    }
+//         $('#settings_webcam h3:first-of-type').after('<div class="alert alert-printnanny alert-block"><h4 class="alert-heading">Note from PrintNanny</h4><p>The setting below do not apply to PrintNanny\'s web camera!</p><p> Use PrintNanny\'s Camera settings tab instead. </p><p><a data-toggle="tab" href="#settings_plugin_octoprint_nanny" class="btn btn-primary">Open PrintNanny Settings</a></p></div>')
+//     }
 
-    OCTOPRINT_VIEWMODELS.push({
-        construct: CameraWarningViewModel,
-        dependencies: ["loginStateViewModel", "settingsViewModel"],
-        elements: ["#settings_webcam"]
-    });
-});
+//     OCTOPRINT_VIEWMODELS.push({
+//         construct: CameraWarningViewModel,
+//         dependencies: ["loginStateViewModel", "settingsViewModel"],
+//         elements: ["#settings_webcam"]
+//     });
+// });
 
 $(function () {
     function PrintNannySettingsViewModel(parameters) {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.6
+current_version = 0.14.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>(dev|rc))+(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ plugin_package = "octoprint_nanny"
 plugin_name = "OctoPrint-Nanny"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.13.6"
+plugin_version = "0.14.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
An HLS compatibility mode is now provided for OctoPrint, so this warning is no longer needed.
https://github.com/bitsy-ai/printnanny-os/issues/103