### PR TITLE
Remove Configure PrintNanny OS button

### DIFF
--- a/octoprint_nanny/templates/octoprint_nanny_settings_shared.jinja2
+++ b/octoprint_nanny/templates/octoprint_nanny_settings_shared.jinja2
@@ -66,13 +66,10 @@
     <h2>🔗 Quick Links</h2>
 
     <h3>Dashboard</h3>
-    <a target="_blank" href="/"><button class="btn btn-primary">PrintNanny OS</button></a>
-    <a target="_blank" href="https://printnanny.ai/devices"><button class="btn btn-primary">PrintNanny Cloud</button></a>
+    <a target="_blank" href="/"><button class="btn btn-primary">PrintNanny OS Dashboard</button></a>
+    <a target="_blank" href="https://printnanny.ai/devices"><button class="btn btn-primary">PrintNanny Cloud Dashboard</button></a>
 <hr>
     <h3>Docs</h3>
     <a target="_blank" href="https://printnanny.ai/docs/category/release-history/" target="_blank"><button class="btn btn-secondary">PrintNanny OS Release History</button></a>
     <a target="_blank" href="https://printnanny.ai/docs/quick-start/configure-file-sync/"><button class="btn btn-secondary">Configure File Sync</button></a>
-        <a target="_blank" href="https://printnanny.ai/docs/quick-start/configure-printnanny-os/"><button class="btn btn-secondary">Configure PrintNanny OS</button></a>
-
-    <hr>
 </div>


### PR DESCRIPTION
This doc used to instruct users how to manually download PrintNanny license - but this is superseded by connecting PrintNanny Cloud account in the dashboard. 