### PR TITLE
Fix: OctoPrint fails to load PrintNanny Cloud data #248

### DIFF
--- a/octoprint_nanny/utils/printnanny_os.py
+++ b/octoprint_nanny/utils/printnanny_os.py
@@ -58,7 +58,7 @@ def load_api_config(api_config_dict: Dict[str, str]) -> PrintNannyApiConfig:
 
 
 async def load_printnanny_cloud_data():
-    cmd = [PRINTNANNY_BIN, "cloud", "show", "--format", "json"]
+    cmd = [PRINTNANNY_BIN, "cloud", "show"]
     # run /usr/bin/printnanny cloud show --format json
     try:
         p = subprocess.run(cmd, capture_output=True)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ plugin_requires = [
     "typing_extensions ; python_version < '3.8'",
     "pytz",
     "aiohttp[speedups]>=3.7.4",
-    "printnanny-api-client>=0.124.8",
+    "printnanny-api-client>=0.126",
     "backoff>=1.10.0",
     "nats-py[nkeys]==2.2.0",
 ]


### PR DESCRIPTION
ref: https://github.com/bitsy-ai/printnanny-os/issues/248
