### PR TITLE
Remove dependency on Cloud data model id

### DIFF
--- a/octoprint_nanny/events.py
+++ b/octoprint_nanny/events.py
@@ -3,7 +3,6 @@ import nats
 from typing import Dict, Any, Optional, TypedDict, Callable
 import socket
 import os
-import json
 from octoprint_nanny.utils import printnanny_os
 
 import printnanny_api_client.models
@@ -247,9 +246,8 @@ async def try_publish_nats(event: str, payload: Dict[Any, Any]) -> bool:
                     event,
                 )
                 return False
-        pi_id = printnanny_os.PRINTNANNY_CLOUD_PI.id
-
-        subject = octoprint_event_to_nats_subject(event, pi_id)
+        hostname = socket.gethostname()
+        subject = octoprint_event_to_nats_subject(event, hostname)
         if subject is None:
             return False
         msg = build_nats_msg(event, payload)

--- a/octoprint_nanny/events.py
+++ b/octoprint_nanny/events.py
@@ -234,18 +234,6 @@ async def try_publish_nats(event: str, payload: Dict[Any, Any]) -> bool:
             )
             logger.info("Connected to NATS server: %s", PRINTNANNY_OS_NATS_URL)
 
-        # bail if PRINTNANNY_CLOUD_PI is not set
-        if printnanny_os.PRINTNANNY_CLOUD_PI is None:
-            logger.warning(
-                "printnanny_os.PRINTNANNY_CLOUD_PI is not set, attempting to load",
-            )
-            await printnanny_os.load_printnanny_cloud_data()
-            if printnanny_os.PRINTNANNY_CLOUD_PI is None:
-                logger.warning(
-                    "printnanny_os.PRINTNANNY_CLOUD_PI is not set, ignoring %s",
-                    event,
-                )
-                return False
         hostname = socket.gethostname()
         subject = octoprint_event_to_nats_subject(event, hostname)
         if subject is None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import patch, MagicMock, AsyncMock
 from octoprint_nanny.events import octoprint_event_to_nats_subject, try_publish_nats
 from octoprint_nanny.utils import printnanny_os
+import socket
 
 MOCK_PI_JSON = """{
     "id": 2,
@@ -94,5 +95,6 @@ async def test_handle_tracked_event(mock_nats):
     assert mock_nats.called is True
     assert mock_nats.return_value.publish.called is True
     call_args = mock_nats.return_value.publish.call_args[0]
-    assert call_args[0] == "pi.2.octoprint.event.server.startup"
+    hostname = socket.gethostname()
+    assert call_args[0] == f"pi.{hostname}.octoprint.event.server.startup"
     assert call_args[1] == b'{"status": "Startup"}'


### PR DESCRIPTION
Publish NATS messages to a subject parameterized by hostname instead of Cloud ID
