### PR TITLE
Fix incorrect progress data

### DIFF
--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -133,9 +133,13 @@ class OctoPrintNannyPlugin(
 
     ##~~ Progress plugin
 
-    def on_print_progress(self, storage, path, progress):
-        octoprint_job = self._printer.get_current_job()
-        payload = dict(job=octoprint_job, storage=storage, path=path, progress=progress)
+    def on_print_progress(self, storage, path, _progress):
+        current_state_data = self._printer.get_current_data()
+        logger.info("on_print_progress state data: %s".current_state_data)
+        job = current_state_data.pop("job")
+        progress = current_state_data.pop("progress")
+
+        payload = dict(job=job, storage=storage, path=path, progress=progress)
         self.on_event(Events.PRINT_PROGRESS, payload)
 
     ##~~ SettingsPlugin mixin

--- a/octoprint_nanny/plugins.py
+++ b/octoprint_nanny/plugins.py
@@ -135,7 +135,7 @@ class OctoPrintNannyPlugin(
 
     def on_print_progress(self, storage, path, _progress):
         current_state_data = self._printer.get_current_data()
-        logger.info("on_print_progress state data: %s".current_state_data)
+        logger.info("on_print_progress state data: %s", current_state_data)
         job = current_state_data.pop("job")
         progress = current_state_data.pop("progress")
 


### PR DESCRIPTION
Fixes the following error in the currently nightly:
```
Mar 28 16:39:35 dev-rpi4 octoprint[785]:   File "/usr/lib/python3.10/site-packages/octoprint_nanny/events.py", line 101, in printnanny_nats_print_progress_msg
Mar 28 16:39:35 dev-rpi4 octoprint[785]:     progress = printnanny_octoprint_models.JobProgress(**progress_kwargs)
Mar 28 16:39:35 dev-rpi4 octoprint[785]: TypeError: printnanny_octoprint_models.JobProgress.JobProgress() argument after ** must be a mapping, not int
```